### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Key | Value | Description
 cenID | CEN ID | CEN Identifier
 wiring_type | bus, wire, or null | type of wiring used
 contIDs | list of container IDs | containers in the CEN
+ip_address | string | (only for bus) IP address of the bridge
 
 Example:
 ```
@@ -187,6 +188,7 @@ Bridge metadata:
 Key | Value | Description
 --- | ----- | -----------
 status | pending, preparing, ready | Status of the bridge
+ipaddr | String | IP Address of the bridge
 
 Ip Address metadata:
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,37 @@ To test it:
 4. Check the Dobby Visualizer
 [http://localhost:8080/static/www/index.html](http://localhost:8080/static/www/index.html)
 
-> It's not possible to see all the CENs simultaneously as the visualizer
-> can only display one root node at once.
+It's not possible to see all the CENs simultaneously as the visualizer
+can only display one root node at once.
+
+## JSON format example
+```
+{"cenList":
+ [{
+     "cenID" : "cen1",
+     "containerIDs" : [ "c1","c2","c13","c14"]
+  },
+  {
+      "cenID":"cen2",
+      "containerIDs":["c4","c5","c6","c7"]
+  },
+  {
+      "cenID":"cen3",
+      "containerIDs":["c15","c16","c9","c10","c11"]
+  },
+  {
+      "cenID":"cen4",
+      "containerIDs":["c11","c12"]
+  },
+  {
+      "cenID":"cen5",
+      "containerIDs":["c2","c3"]
+  }]
+}
+```
+Where:
+* `cenID` is the CEN identifier
+* `containerIDs` is a list of container identifiers
 
 ## Leviathan Erlang Data Structures
 
@@ -83,6 +112,7 @@ A Wire is represented by a pair of maps in a list. Each map has:
 Key | Value | Description
 --- | ----- | -----------
 endID | endpoint | Endpoint identifier (description above)
+side | in or out | desintation is inside or outside the container
 dest | destination map | See below
 
 A destination map:
@@ -97,25 +127,29 @@ ip_address | string | (only for containers) IP address for interface
 Examples:
 ```
 [#{endID =>"c1.0i",
+   side => in,
    dest => #{type => cont,
              id =>"c1",
              alias =>"eth0",
              ip_address => "10.8.2.13"}},
  #{endID =>"c1.0o",
+   side => out,
    dest => #{type => cen,
              id =>"cen1"}}]
 ```
 ```
 [#{endID =>"c2.2i",
+   side => in,
    dest => #{type => cont,
              id =>"c2",
              alias =>"eth2",
              ip_address => "10.9.2.13"}},
  #{endID =>"c4.0i",
-  dest => #{type => cont,
-            id =>"c4",
-            alias =>"eth0",
-            ip_address => "10.9.2.14"}}]
+   side => in,
+   dest => #{type => cont,
+             id =>"c4",
+             alias =>"eth0",
+             ip_address => "10.9.2.14"}}]
 ```
 
 ## Dobby Data Model

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To test it:
    2. run with `make run cookie=dobby_allinone
 3. Import the `cen.json`
    ```erlang
-   leviathan_cen:import_cen_to_dobby("cen.json").
+   leviathan_cen:import_file("host1", "cen.json").
    ```
 4. Check the Dobby Visualizer
 [http://localhost:8080/static/www/index.html](http://localhost:8080/static/www/index.html)

--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,7 @@
                       {branch, "master"}}}]
 }.
 
+{eunit_opts, [verbose]}.
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 {erl_opts, [{parse_transform, lager_transform}, debug_info]}.

--- a/src/leviathan_cen.erl
+++ b/src/leviathan_cen.erl
@@ -2,7 +2,8 @@
 
 -compile(export_all).
 
--export([decode_file/1,
+-export([import_file/2,
+         decode_file/1,
          decode_binary/1,
          remove_container_from_cen/3,
          add_container_to_cen/3,
@@ -19,6 +20,10 @@
 % API
 %-------------------------------------------------------------------------------
 
+import_file(Host, Filename) ->
+    LM = decode_file(Filename),
+    ok = leviathan_dby:import_cens(Host, LM).
+
 decode_file(Filename) ->
     {ok, Binary} = file:read_file(Filename),
     decode_binary(Binary).
@@ -26,7 +31,6 @@ decode_file(Filename) ->
 decode_binary(Binary) ->
     #{<<"cenList">> := Cens} = jiffy:decode(Binary, [return_maps]),
     decode_jiffy(Cens).
-
 
 % Add a container to a CEN
 add_container_to_cen(HostId, ContainerId, CenId) ->
@@ -55,12 +59,12 @@ destroy_cen(CenId) ->
     ok.
 
 % To test:
-% 1. load the cen.json file in this repo via leviathan_dby:import_file/2
+% 1. load the cen.json file in this repo via leviathan_cen:import_file/2
 %    or use curl and the REST interface (see leviathan_rest_lib).
 %    The host name must be "host1"
 % 2. test_cens/0 returns the cen IDs of the cens in the .json file, so
 %    you can use that to save typing
-% 3. inspect the levmap:
+% 3. (optional) inspect the levmap:
 %       leviathan_cen:get_levmap(leviathan_cen:test_cens()).
 % 4. test prepare:
 %       leviathan_cen:test_local_prepare_lev(leviathan_cen:test_cens()).

--- a/src/leviathan_cin.erl
+++ b/src/leviathan_cin.erl
@@ -16,7 +16,6 @@ prepare_wire_end(#{type := cont, id := ContId, alias := Alias, ip_address := IPA
     CmdBundle = leviathan_linux:set_ip_address(ContId, Alias, IPAddress),
     leviathan_linux:eval(CmdBundle).
 
-
 cen_ip_address(NetCount) when NetCount =< 244 ->
     B = NetCount + 6, %% offset
     list_to_binary(inet_parse:ntoa({10, B, 0, 1})).

--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -21,13 +21,13 @@
 %
 % -----------------------------------------------------------------------------
 
-% json file
+% import CENs
 
 import_cens(Host, CensMap) ->
     ToPublish = [container_from_censmap(Host, CensMap),
                  cens_from_censmap(Host, CensMap),
                  wires_from_censmap(Host, CensMap)],
-    dby:publish(?PUBLISHER, lists:flatten(ToPublish), [persistent]).
+    ok = dby:publish(?PUBLISHER, lists:flatten(ToPublish), [persistent]).
 
 % getters
 

--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -202,7 +202,8 @@ wire_cen(Host, Endpoint1 = #{endID := EndId1},
     [
         endpoint(Host, Endpoint1),
         endpoint(Host, Endpoint2),
-        dby_endpoint_to_endpoint(Host, EndId1, EndId2, <<"conntected_to">>)
+        dby_endpoint_to_endpoint(Host, EndId1, EndId2,
+                endpoint_to_endpoint_type(Endpoint1, Endpoint2))
     ].
 
 endpoint(Host, #{endID := EndId,
@@ -210,7 +211,7 @@ endpoint(Host, #{endID := EndId,
                  dest := #{type := cont,
                            id := ContId,
                            alias := Eth,
-                           ip_addres := IpAddr}}) ->
+                           ip_address := IpAddr}}) ->
     [
         dby_endpoint(Host, EndId, Side, [alias_md(Eth), status_md(pending)]),
         dby_ipaddr(IpAddr),
@@ -225,6 +226,13 @@ endpoint(Host, #{endID := EndId,
         dby_endpoint(Host, EndId, Side, [status_md(pending)]),
         dby_endpoint_to_bridge(Host, EndId, CenId)
     ].
+
+endpoint_to_endpoint_type(#{dest := #{type := cont, id := ContId1}},
+                          #{dest := #{type := cont, id := ContId2}})
+                                                when ContId1 /= ContId2 ->
+    <<"connected_to">>;
+endpoint_to_endpoint_type(_,_) ->
+    <<"veth_peer">>.
 
 status_md(pending) ->
     {<<"status">>, <<"pending">>};
@@ -248,9 +256,9 @@ wire_type_md(bus) ->
 alias_md(Alias) ->
     {<<"alias">>, Alias}.
 
-endpoint_side_md(inside) ->
+endpoint_side_md(in) ->
     {<<"side">>, <<"in">>};
-endpoint_side_md(outside) ->
+endpoint_side_md(out) ->
     {<<"side">>, <<"out">>}.
 
 md_wire_type(null) ->

--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -1,6 +1,8 @@
 -module(leviathan_dby).
 
+-ifndef(TEST).
 -on_load(install_iso8601/0).
+-endif.
 
 -export([import_file/2,
          import_binary/2,

--- a/test/leviathan_cen_test.erl
+++ b/test/leviathan_cen_test.erl
@@ -51,7 +51,7 @@ decode_jiffy3() ->
 
 decode_jiffy4() ->
     Json = [json_cen(<<"cen1">>, [<<"c1">>, <<"c2">>, <<"c3">>])],
-    Cen1 = cen_map(<<"cen1">>, [<<"c1">>, <<"c2">>, <<"c3">>], bus),
+    Cen1 = cen_map(<<"cen1">>, [<<"c1">>, <<"c2">>, <<"c3">>], bus, <<"10.7.0.1">>),
     Cont1 = cont_map(<<"c1">>, [<<"cen1">>]),
     Cont2 = cont_map(<<"c2">>, [<<"cen1">>]),
     Cont3 = cont_map(<<"c3">>, [<<"cen1">>]),
@@ -86,6 +86,9 @@ cen_map(CenId, ContIds, WireType) ->
       wire_type => WireType,
       contIDs => ContIds}.
 
+cen_map(CenId, ContIds, WireType, IpAddr) ->
+    (cen_map(CenId, ContIds, WireType))#{ipaddr => IpAddr}.
+
 cont_map(ContId, CenIds) ->
     #{contID => ContId,
       cens => CenIds}.
@@ -108,4 +111,4 @@ tr() ->
     dbg:start(),
     dbg:tracer(),
     dbg:p(all, c),
-    dbg:tpl(levaithan_cen, []).
+    dbg:tpl(leviathan_cen, []).

--- a/test/leviathan_cen_test.erl
+++ b/test/leviathan_cen_test.erl
@@ -39,8 +39,8 @@ decode_jiffy3() ->
     Cont1 = cont_map(<<"c1">>, [<<"cen1">>]),
     Cont2 = cont_map(<<"c2">>, [<<"cen1">>]),
     Wire = [
-        endpoint(<<"c1">>, <<"c1.0i">>, in, <<"eth0">>, <<"10.7.0.10">>),
-        endpoint(<<"c2">>, <<"c2.0i">>, in, <<"eth0">>, <<"10.7.0.11">>)
+        endpoint(<<"c1">>, <<"c1.0i">>, in, <<"cen1">>, <<"10.7.0.10">>),
+        endpoint(<<"c2">>, <<"c2.0i">>, in, <<"cen1">>, <<"10.7.0.11">>)
     ],
     #{censmap := #{cens := Cens},
       contsmap := #{conts := Conts},
@@ -56,15 +56,15 @@ decode_jiffy4() ->
     Cont2 = cont_map(<<"c2">>, [<<"cen1">>]),
     Cont3 = cont_map(<<"c3">>, [<<"cen1">>]),
     Wire1 = [
-        endpoint(<<"c1">>, <<"c1.0i">>, in, <<"eth0">>, <<"10.7.0.10">>),
+        endpoint(<<"c1">>, <<"c1.0i">>, in, <<"cen1">>, <<"10.7.0.10">>),
         endpoint(<<"cen1">>, <<"c1.0o">>, out)
     ],
     Wire2 = [
-        endpoint(<<"c2">>, <<"c2.0i">>, in, <<"eth0">>, <<"10.7.0.11">>),
+        endpoint(<<"c2">>, <<"c2.0i">>, in, <<"cen1">>, <<"10.7.0.11">>),
         endpoint(<<"cen1">>, <<"c2.0o">>, out)
     ],
     Wire3 = [
-        endpoint(<<"c3">>, <<"c3.0i">>, in, <<"eth0">>, <<"10.7.0.12">>),
+        endpoint(<<"c3">>, <<"c3.0i">>, in, <<"cen1">>, <<"10.7.0.12">>),
         endpoint(<<"cen1">>, <<"c3.0o">>, out)
     ],
     #{censmap := #{cens := Cens},

--- a/test/leviathan_cen_test.erl
+++ b/test/leviathan_cen_test.erl
@@ -1,0 +1,111 @@
+-module(leviathan_cen_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(assertEqualLists(A,B), ?assertEqual(lists:sort(A), lists:sort(B))).
+
+leviathan_cen_test_() ->
+    [
+        {"decode_jiffy 0 containers", fun decode_jiffy1/0}
+       ,{"decode_jiffy 1 container", fun decode_jiffy2/0}
+       ,{"decode_jiffy 2 containers", fun decode_jiffy3/0}
+       ,{"decode_jiffy 3 containers", fun decode_jiffy4/0}
+    ].
+
+decode_jiffy1() ->
+    Json = [json_cen(<<"cen1">>, [])],
+    Cen1 = cen_map(<<"cen1">>, [], null),
+    #{censmap := #{cens := Cens},
+      contsmap := #{conts := Conts},
+      wiremap := #{wires := Wires}} = leviathan_cen:decode_jiffy(Json),
+    ?assertEqualLists([Cen1], Cens),
+    ?assertEqualLists([], Conts),
+    ?assertEqualLists([], Wires).
+
+decode_jiffy2() ->
+    Json = [json_cen(<<"cen1">>, [<<"c1">>])],
+    Cen1 = cen_map(<<"cen1">>, [<<"c1">>], null),
+    Cont1 = cont_map(<<"c1">>, [<<"cen1">>]),
+    #{censmap := #{cens := Cens},
+      contsmap := #{conts := Conts},
+      wiremap := #{wires := Wires}} = leviathan_cen:decode_jiffy(Json),
+    ?assertEqualLists([Cen1], Cens),
+    ?assertEqualLists([Cont1], Conts),
+    ?assertEqualLists([], Wires).
+
+decode_jiffy3() ->
+    Json = [json_cen(<<"cen1">>, [<<"c1">>, <<"c2">>])],
+    Cen1 = cen_map(<<"cen1">>, [<<"c1">>, <<"c2">>], wire),
+    Cont1 = cont_map(<<"c1">>, [<<"cen1">>]),
+    Cont2 = cont_map(<<"c2">>, [<<"cen1">>]),
+    Wire = [
+        endpoint(<<"c1">>, <<"c1.0i">>, in, <<"eth0">>, <<"10.7.0.10">>),
+        endpoint(<<"c2">>, <<"c2.0i">>, in, <<"eth0">>, <<"10.7.0.11">>)
+    ],
+    #{censmap := #{cens := Cens},
+      contsmap := #{conts := Conts},
+      wiremap := #{wires := Wires}} = leviathan_cen:decode_jiffy(Json),
+    ?assertEqualLists([Cen1], Cens),
+    ?assertEqualLists([Cont1, Cont2], Conts),
+    ?assertEqualLists([Wire], Wires).
+
+decode_jiffy4() ->
+    Json = [json_cen(<<"cen1">>, [<<"c1">>, <<"c2">>, <<"c3">>])],
+    Cen1 = cen_map(<<"cen1">>, [<<"c1">>, <<"c2">>, <<"c3">>], bus),
+    Cont1 = cont_map(<<"c1">>, [<<"cen1">>]),
+    Cont2 = cont_map(<<"c2">>, [<<"cen1">>]),
+    Cont3 = cont_map(<<"c3">>, [<<"cen1">>]),
+    Wire1 = [
+        endpoint(<<"c1">>, <<"c1.0i">>, in, <<"eth0">>, <<"10.7.0.10">>),
+        endpoint(<<"cen1">>, <<"c1.0o">>, out)
+    ],
+    Wire2 = [
+        endpoint(<<"c2">>, <<"c2.0i">>, in, <<"eth0">>, <<"10.7.0.11">>),
+        endpoint(<<"cen1">>, <<"c2.0o">>, out)
+    ],
+    Wire3 = [
+        endpoint(<<"c3">>, <<"c3.0i">>, in, <<"eth0">>, <<"10.7.0.12">>),
+        endpoint(<<"cen1">>, <<"c3.0o">>, out)
+    ],
+    #{censmap := #{cens := Cens},
+      contsmap := #{conts := Conts},
+      wiremap := #{wires := Wires}} = leviathan_cen:decode_jiffy(Json),
+    ?assertEqualLists([Cen1], Cens),
+    ?assertEqualLists([Cont1, Cont2, Cont3], Conts),
+    ?assertEqualLists([Wire1, Wire2, Wire3], Wires).
+
+%-------------------------------------------------------------------------------
+% helpers
+%-------------------------------------------------------------------------------
+
+json_cen(CenId, ContIds) ->
+    #{<<"cenID">> => CenId, <<"containerIDs">> => ContIds}.
+
+cen_map(CenId, ContIds, WireType) ->
+    #{cenID => CenId,
+      wire_type => WireType,
+      contIDs => ContIds}.
+
+cont_map(ContId, CenIds) ->
+    #{contID => ContId,
+      cens => CenIds}.
+
+endpoint(ContId, EndId, Side, Alias, IpAddr) ->
+    #{endID => EndId,
+      side => Side,
+      dest => #{alias => Alias,
+                id => ContId,
+                ip_address => IpAddr,
+                type => cont}}.
+
+endpoint(CenId, EndId, Side) ->
+    #{endID => EndId,
+      side => Side,
+      dest => #{id => CenId,
+                type => cen}}.
+
+tr() ->
+    dbg:start(),
+    dbg:tracer(),
+    dbg:p(all, c),
+    dbg:tpl(levaithan_cen, []).


### PR DESCRIPTION
Move CEN related data manipulation out of leviathan_dby into leviathan_cen. leviathan_dby now accepts CEN data structures rather than the JSON. leviathan_cen translates the JSON to the CEN structures and computes the wiring.
