### PR TITLE
Start OpenFlow switches from within Leviathan

### DIFF
--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -5,7 +5,8 @@
 -endif.
 
 -export([import_cens/2,
-         update_cens/2]).
+         update_cens/2,
+         import_switch/2]).
 
 -export([get_cen/1,
          get_cont/2,
@@ -28,6 +29,15 @@ import_cens(Host, CensMap) ->
     ToPublish = [container_from_lm(Host, CensMap),
                  cens_from_lm(Host, CensMap),
                  wires_from_lm(Host, CensMap)],
+    ok = dby:publish(?PUBLISHER, lists:flatten(ToPublish), [persistent]).
+
+% import switch
+
+import_switch(Host, Switch) ->
+    ToPublish = [dby_switch(Host, Switch),
+                 switch_ports(Host, Switch),
+                 %% One flow table should be enough for everyone.
+                 switch_tables(Host, Switch, 1)],
     ok = dby:publish(?PUBLISHER, lists:flatten(ToPublish), [persistent]).
 
 % getters
@@ -140,6 +150,15 @@ dby_endpoint_id(Host, Endpoint) ->
 dby_ipaddr_id(IpAddr) ->
     dby_id([<<"lev_ip">>, IpAddr]).
 
+dby_switch_id(Host, ContId) ->
+    dby_id([<<"lev_switch">>, Host, ContId]).
+
+dby_of_port_id(SwitchId, N) ->
+    <<SwitchId/binary, "/OFP", (integer_to_binary(N))/binary>>.
+
+dby_of_flow_table_id(SwitchId, N) ->
+    <<SwitchId/binary, "-table-", (integer_to_binary(N))/binary>>.
+
 dby_cen(CenId, Metadata) when is_binary(CenId) ->
     {dby_cen_id(CenId), [{<<"cenID">>, CenId},
 			 {<<"type">>, <<"cen">>}] ++ Metadata}.
@@ -160,6 +179,20 @@ dby_endpoint(Host, EndID, Side, Metadata) when is_binary(EndID) ->
 dby_ipaddr(IpAddr) when is_binary(IpAddr) ->
     {dby_ipaddr_id(IpAddr), [{<<"type">>, <<"ipaddr">>},
                              {<<"ipaddr">>, IpAddr}]}.
+
+dby_switch(Host, #{<<"contID">> := ContId}) ->
+    {dby_switch_id(Host, ContId),
+     [{<<"contID">>, ContId},
+      {<<"type">>, <<"of_switch">>}]}.
+
+dby_of_port(SwitchId, N) ->
+    {dby_of_port_id(SwitchId, N),
+     [{<<"type">>, <<"of_port">>}]}.
+
+dby_of_flow_table(SwitchId, N) ->
+    {dby_of_flow_table_id(SwitchId, N),
+     [{<<"type">>, <<"of_flow_table">>},
+      {<<"table_no">>, N}]}.
 
 dby_endpoint_to_ipaddr(Host, EndpointId, IpAddr) ->
     dby_link(dby_endpoint_id(Host, EndpointId), dby_ipaddr_id(IpAddr),
@@ -245,6 +278,22 @@ wires_from_lm(Host, #{wiremap := #{wires := Wires}}) ->
         fun(Wire, Acc) ->
             [pub_wire(Host, Wire) | Acc]
         end, [], Wires).
+
+switch_ports(Host, #{<<"contID">> := ContID, <<"interfaces">> := InterfacesBin}) ->
+    SwitchId = dby_switch_id(Host, ContID),
+    NumberedInterfaces = lists:zip(lists:seq(1, length(InterfacesBin)), InterfacesBin),
+    [
+     [dby_of_port(SwitchId, N),
+      dby_link(dby_of_port_id(SwitchId, N), SwitchId, <<"part_of">>),
+      dby_link(dby_of_port_id(SwitchId, N), dby_bridge_id(Host, Interface), <<"bound_to">>)]
+     || {N, Interface} <- NumberedInterfaces].
+
+switch_tables(Host, #{<<"contID">> := ContID}, HowMany) ->
+    SwitchId = dby_switch_id(Host, ContID),
+    [
+     [dby_of_flow_table(SwitchId, N),
+      dby_link(dby_of_flow_table_id(SwitchId, N), SwitchId, <<"of_resource">>)]
+     || N <- lists:seq(0, HowMany - 1)].
 
 % prepare to publish one wire
 pub_wire(Host, [Endpoint1 = #{endID := EndId1},

--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -201,10 +201,11 @@ dby_ipaddr(IpAddr) when is_binary(IpAddr) ->
     {dby_ipaddr_id(IpAddr), [{<<"type">>, <<"ipaddr">>},
                              {<<"ipaddr">>, IpAddr}]}.
 
-dby_switch(Host, #{<<"contID">> := ContId}) ->
+dby_switch(Host, #{<<"contID">> := ContId, <<"datapath_id">> := DatapathId}) ->
     {dby_switch_id(Host, ContId),
      [{<<"contID">>, ContId},
-      {<<"type">>, <<"of_switch">>}]}.
+      {<<"type">>, <<"of_switch">>},
+      {<<"datapath_id">>, DatapathId}]}.
 
 dby_of_port(SwitchId, N) ->
     {dby_of_port_id(SwitchId, N),

--- a/src/leviathan_ip.erl
+++ b/src/leviathan_ip.erl
@@ -50,4 +50,9 @@ netns_exec_ip_addr_add_dev(CPid,Address,DevName)->
 netns_exec_ip_route_add_default_via(CPid,Address)->
     "ip netns exec "  ++ CPid ++ " ip route add default via " ++ Address.
     
+%
+% Example: "ip netns exec $pid ip route add default dev cen2"
+%
+netns_exec_ip_route_add_default_dev(CPid,DevName)->
+    "ip netns exec "  ++ CPid ++ " ip route add default dev " ++ DevName.
     

--- a/src/leviathan_linux.erl
+++ b/src/leviathan_linux.erl
@@ -84,7 +84,9 @@ set_ip_address(Cid, Alias, IPAddress)->
     %% Use /0 as netmask, since the concept of "local network" doesn't
     %% make sense anymore.  Since the entire world is now our local
     %% network, we don't need a gateway either.
-    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/0",Alias)].
+    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/0",Alias),
+     %% Add a route to send everything out through the network interface.
+     leviathan_ip:netns_exec_ip_route_add_default_dev(CPid,Alias)].
 
 eval(CmdBundle)->
     EvalBundle = lists:map(fun(X)->Result = leviathan_os:cmd(X), {X,Result} end,CmdBundle),

--- a/src/leviathan_linux.erl
+++ b/src/leviathan_linux.erl
@@ -81,11 +81,10 @@ new_bridge(BridgeNum)->
 
 set_ip_address(Cid, Alias, IPAddress)->
     CPid = leviathan_docker:inspect_pid(Cid),
-    {ok,{A,B,_,_}} = inet:parse_ipv4_address(IPAddress),
-    Gateway = {A,B,0,1},
-    GatewayString = inet:ntoa(Gateway),
-    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/16",Alias), %% XXX hardcoded to /16
-     leviathan_ip:netns_exec_ip_route_add_default_via(CPid,GatewayString)].
+    %% Use /0 as netmask, since the concept of "local network" doesn't
+    %% make sense anymore.  Since the entire world is now our local
+    %% network, we don't need a gateway either.
+    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/0",Alias)].
 
 eval(CmdBundle)->
     EvalBundle = lists:map(fun(X)->Result = leviathan_os:cmd(X), {X,Result} end,CmdBundle),

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -37,15 +37,16 @@ run_switch(CType, Interfaces) ->
     {ok, ContainerId, DatapathId}.
 
 wait_for_new_connection(AlreadyConnected) ->
-    wait_for_new_connection(AlreadyConnected, 100).
+    wait_for_new_connection(AlreadyConnected, 10000).
 
-wait_for_new_connection(_, 0) ->
+wait_for_new_connection(_, N) when N =< 0 ->
     error(switch_connection_timeout);
 wait_for_new_connection(AlreadyConnected, N) when N > 0 ->
     case weave_ofsh:all_connected() -- AlreadyConnected of
         [] ->
-            timer:sleep(10),
-            wait_for_new_connection(AlreadyConnected, N - 1);
+            Sleep = 10,
+            timer:sleep(Sleep),
+            wait_for_new_connection(AlreadyConnected, N - Sleep);
         [DatapathId] ->
             list_to_binary(DatapathId)
     end.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -17,15 +17,35 @@ import_json(#{<<"type">> := CTypeBin,
               <<"interfaces">> := InterfacesBin} = Switch) ->
     CType = binary_to_list(CTypeBin),
     Interfaces = lists:map(fun binary_to_list/1, InterfacesBin),
-    {ok, ContainerId} = run_switch(CType, Interfaces),
-    %% XXX: get the datapath id!
-    DatapathId = <<"this-is-not-the-datapath-id-", ContainerId/binary>>,
+    {ok, ContainerId, DatapathId} = run_switch(CType, Interfaces),
     NewSwitch = Switch#{<<"contID">> => ContainerId,
                         <<"datapath_id">> => DatapathId},
     leviathan_dby:import_switch(<<"host1">>, NewSwitch).
 
 run_switch(CType, Interfaces) ->
+    AlreadyConnected = weave_ofsh:all_connected(),
+
     CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],
     [ContainerId] = leviathan_linux:eval(CmdBundle, output),
     io:format("switch results:~n~p~n", [ContainerId]),
-    {ok, ContainerId}.
+
+    %% XXX: Here we wait for a new incoming switch connection, and
+    %% assume that it's coming from the newly started container.  This
+    %% is a potential race condition.
+    DatapathId = wait_for_new_connection(AlreadyConnected),
+
+    {ok, ContainerId, DatapathId}.
+
+wait_for_new_connection(AlreadyConnected) ->
+    wait_for_new_connection(AlreadyConnected, 100).
+
+wait_for_new_connection(_, 0) ->
+    error(switch_connection_timeout);
+wait_for_new_connection(AlreadyConnected, N) when N > 0 ->
+    case weave_ofsh:all_connected() -- AlreadyConnected of
+        [] ->
+            timer:sleep(10),
+            wait_for_new_connection(AlreadyConnected, N - 1);
+        [DatapathId] ->
+            list_to_binary(DatapathId)
+    end.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -1,0 +1,11 @@
+-module(leviathan_switch).
+
+-compile(export_all).
+
+-include("leviathan_logger.hrl").
+
+run_switch(CType, Interfaces) ->
+    CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],
+    Result = leviathan_linux:eval(CmdBundle, output),
+    io:format("switch results:~n~p~n", [Result]),
+    ok.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -1,11 +1,27 @@
 -module(leviathan_switch).
 
--compile(export_all).
+-export(
+   [import_binary/1,
+    import_json/1,
+    run_switch/2]).
 
 -include("leviathan_logger.hrl").
 
+import_binary(Binary) ->
+    SwitchMap = jiffy:decode(Binary, [return_maps]),
+    import_json(SwitchMap).
+
+import_json(Switches) when is_list(Switches) ->
+    lists:foreach(fun import_json/1, Switches);
+import_json(#{<<"type">> := CTypeBin,
+              <<"interfaces">> := InterfacesBin} = Switch) ->
+    CType = binary_to_list(CTypeBin),
+    Interfaces = lists:map(fun binary_to_list/1, InterfacesBin),
+    {ok, ContainerId} = run_switch(CType, Interfaces),
+    leviathan_dby:import_switch(<<"host1">>, Switch#{<<"contID">> => ContainerId}).
+
 run_switch(CType, Interfaces) ->
     CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],
-    Result = leviathan_linux:eval(CmdBundle, output),
-    io:format("switch results:~n~p~n", [Result]),
-    ok.
+    [ContainerId] = leviathan_linux:eval(CmdBundle, output),
+    io:format("switch results:~n~p~n", [ContainerId]),
+    {ok, ContainerId}.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -1,16 +1,46 @@
+%% @doc
+%% This module starts an OpenFlow switch and publishes the appropriate
+%% information to Dobby.
+%%
+%% Use it like this:
+%%
+%% ```
+%%     leviathan_switch:import_json(
+%%       #{<<"type">> => <<"local/linc">>,
+%%         <<"interfaces">> => [<<"cen1">>, <<"cen2">>]}).
+%% '''
+%%
+%% The Docker image named in the `type' attribute will be started with
+%% the options `--net=host --privileged=true', and the interface names
+%% will be passed as command line arguments.  The Docker image should
+%% have an `ENTRYPOINT' appropriately set to accept those arguments.
 -module(leviathan_switch).
 
 -export(
    [import_binary/1,
-    import_json/1,
-    run_switch/2]).
+    import_json/1]).
 
 -include("leviathan_logger.hrl").
 
+%% @doc Start one or more switches based on a JSON description.
+%%
+%% This function parses `Binary' as JSON and passes it to {@link
+%% import_json/1}.
 import_binary(Binary) ->
     SwitchMap = jiffy:decode(Binary, [return_maps]),
     import_json(SwitchMap).
 
+%% @doc Start one or more switches, and publish info to Dobby.
+%%
+%% The argument can be a single map, or a list of maps.  Each
+%% map should have two keys:
+%%
+%% The `<<"type">>' key should have a binary value, that names a
+%% Docker image.
+%%
+%% The `<<"interfaces">>' key should have a list of binaries,
+%% each naming an interface name that the newly started switch
+%% should manage.
 import_json(Switches) when is_list(Switches) ->
     lists:foreach(fun import_json/1, Switches);
 import_json(#{<<"type">> := CTypeBin,
@@ -22,6 +52,7 @@ import_json(#{<<"type">> := CTypeBin,
                         <<"datapath_id">> => DatapathId},
     leviathan_dby:import_switch(<<"host1">>, NewSwitch).
 
+%% @doc Start a switch, without publishing anything to Dobby.
 run_switch(CType, Interfaces) ->
     AlreadyConnected = weave_ofsh:all_connected(),
 

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -18,7 +18,11 @@ import_json(#{<<"type">> := CTypeBin,
     CType = binary_to_list(CTypeBin),
     Interfaces = lists:map(fun binary_to_list/1, InterfacesBin),
     {ok, ContainerId} = run_switch(CType, Interfaces),
-    leviathan_dby:import_switch(<<"host1">>, Switch#{<<"contID">> => ContainerId}).
+    %% XXX: get the datapath id!
+    DatapathId = <<"this-is-not-the-datapath-id-", ContainerId/binary>>,
+    NewSwitch = Switch#{<<"contID">> => ContainerId,
+                        <<"datapath_id">> => DatapathId},
+    leviathan_dby:import_switch(<<"host1">>, NewSwitch).
 
 run_switch(CType, Interfaces) ->
     CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],


### PR DESCRIPTION
This pull request introduces the `leviathan_switch` module, which contains functions for starting switches from within Leviathan. The `import_binary` function can accept a JSON binary, but the corresponding endpoint in `leviathan_rest` is not yet written. The `import_json` function accepts a map, and is more convenient for calling from the Erlang shell.

Switches are started as Docker containers, using the given Docker image name. Images are expected to follow the convention described in the documentation of the `leviathan_switch` module: they should accept a number of network interfaces as command line arguments, and start the switch automatically.
