### PR TITLE
Add reservedIps and reservedIdNums

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,22 @@ Key | Value | Description
 cenID | CEN ID | CEN Identifier
 wire_type | bus, wire, or null | type of wiring used
 contIDs | list of container IDs | containers in the CEN
-ipaddr | string | (only for bus) IP address of the bridge
+ipaddr_b | integer | (only for bus) B part of the IP addresses for CEN
+ipaddress | string | IP address of bridge
+reservedIp | list of strings | Ip addresses in use in this CEN
+
+The list of containers in the CEN and the list of reserved IP addresses
+are in the same order. That is, the first container uses the first IP
+address.
 
 Example:
 ```
-#{cenID => "cen1", wire_type => bus, contIDs => ["c1","c2","c3"]}
+#{cenID => "cen1",
+  wire_type => bus,
+  contIDs => ["c1","c2","c3"],
+  ipaddr_b => 17,
+  reservedIp => ["10.17.0.1", "10.17.0.2", ...]
+}
 ```
 
 A Container is represented by a map:
@@ -136,10 +147,17 @@ Key | Value | Description
 --- | ----- | -----------
 contID | container ID | Container ID
 cens | list of CEN IDs | Container is in these CENs
+reservedIdNums | list of integers | Endpoint interfaces Ids used by this Container
+
+The list of CENs and the list of reserved interface Ids are in the same order.
+That is, the first the container uses the first interface Id for the first CEN.
 
 Example:
 ```
-#{contID => "c1", cens => ["cen1","cen2"]}
+#{contID => "c1",
+  cens => ["cen1","cen2"],
+  reservedIdNums => [0, 1, 2, ...]
+}
 ```
 
 A Wire is represented by a pair of maps in a list. Each map has:

--- a/src/leviathan.hrl
+++ b/src/leviathan.hrl
@@ -24,3 +24,6 @@
                          cen :: string(),
                          data :: #{idnumber => integer(),
                                    ip_address => string()}}).
+
+% persistent counters
+-record(counter, {id :: atom(), count :: integer()}).

--- a/src/leviathan_cen.erl
+++ b/src/leviathan_cen.erl
@@ -286,9 +286,8 @@ add_cen(CenId, LM = ?LM_CENS(Cens)) ->
         true ->
             LM;
         false ->
-            Ip = leviathan_store:get_next_cin_ip(),
-            leviathan_store:add_cen(CenId, Ip),
-            LM?LM_SET_CENS([cen(CenId, null, [], Ip) | Cens])
+            IpB = leviathan_cin:next_cenb(),
+            LM?LM_SET_CENS([cen(CenId, bus, [], IpB) | Cens])
     end.
 
 % returns filter function matching CenId
@@ -320,7 +319,7 @@ add_container_to_censmap(CenId, ContId, LM = ?LM_CENS(Cens0)) ->
     Cens1 = update_censmap(CenId, Cens0,
         fun(Cen = #{contIDs := ContIds0}) ->
             ContIds1 = list_add_unique(ContId, ContIds0),
-            [Cen#{contIDs := ContIds1, wire_type := wire_type(ContIds1)}]
+            [Cen#{contIDs := ContIds1}]
         end),
     LM?LM_SET_CENS(Cens1).
 
@@ -343,7 +342,7 @@ remove_container_from_censmap(CenId, ContId, LM = ?LM_CENS(Cens0)) ->
     Cens1 = update_censmap(CenId, Cens0,
         fun(Cen = #{contIDs := ContIds0}) ->
             ContIds1 = lists:delete(ContId, ContIds0),
-            [Cen#{contIDs := ContIds1, wire_type := wire_type(ContIds0)}]
+            [Cen#{contIDs := ContIds1}]
         end),
     LM?LM_SET_CENS(Cens1).
 
@@ -361,8 +360,10 @@ remove_container_from_contsmap(ContId, CenId, LM = ?LM_CONTS(Conts0)) ->
     LM?LM_SET_CONTS(Conts1).
 
 % Rewire the CENs
-lm_wire_cens(LM = ?LM_CENS(Cens)) ->
-    Wires = wire_cens(Cens),
+lm_wire_cens(LM) ->
+    ?LM_CONTS(Conts) = LM,
+    ?LM_CENS(Cens) = LM,
+    Wires = wire_cens(Cens, Conts),
     LM?LM_SET_WIRES(Wires).
 
 % Compare LMs
@@ -397,17 +398,12 @@ compare_cens_containers(?LM_CENS(OldCens), ?LM_CENS(NewCens)) ->
         fun(CenId) ->
             #{contIDs := OldList} = maps:get(CenId, OldMap),
             #{contIDs := NewList} = maps:get(CenId, NewMap),
-            Ipaddr = maps:get(ip_address, maps:get(CenId, NewMap), null),
             {ToRemove, ToAdd} = compare_lists(OldList, NewList),
             [
                 instructions(destroy, cont_in_cen,
                     [{ContId, CenId}|| ContId <- ToRemove]),
                 instructions(add, cont_in_cen,
-                    [{ContId, CenId} || ContId <- ToAdd]),
-                set_wiretype(CenId, wire_type(OldList),
-                                    wire_type(NewList)),
-                set_bridge(CenId, Ipaddr,
-                                    wire_type(OldList), wire_type(NewList))
+                    [{ContId, CenId} || ContId <- ToAdd])
             ]
         end, CommonKeys).
 
@@ -424,19 +420,6 @@ set_wiretype(_, Wiretype, Wiretype) ->
     [];
 set_wiretype(CenId, _, NewWiretype) ->
     {set, wire_type, {CenId, NewWiretype}}.
-
-set_bridge(_, _, WireType, WireType) ->
-    % nothing changed
-    [];
-set_bridge(CenId, Ipaddr, _, bus) ->
-    % add bridge
-    {add, bridge, {CenId, Ipaddr}};
-set_bridge(CenId, _, bus, _) ->
-    % remove bridge
-    {destroy, bridge, CenId};
-set_bridge(_, _, _, _) ->
-    % ignore any other transition
-    [].
 
 compare_wires(?LM_WIRES(OldWires), ?LM_WIRES(NewWires)) ->
     delta_instructions(wire, wires_map(OldWires), wires_map(NewWires)).
@@ -513,12 +496,10 @@ decode_jiffy(CensJson) ->
     ?DEBUG("CensJson:~n~p~n",[CensJson]),
     Cens = cens_from_jiffy(CensJson),
     Conts = conts_from_jiffy(CensJson),
-    % XXX wires may need to update the Conts with the counts
-    Wires = wire_cens(Cens),
     #{
         censmap => #{cens => Cens},
         contsmap => #{conts => Conts},
-        wiremap => #{wires => Wires}
+        wiremap => #{wires => wire_cens(Cens, Conts)}
     }.
 
 % cens
@@ -526,28 +507,25 @@ cens_from_jiffy(CensJson) ->
     Cens = lists:foldl(
         fun(#{<<"cenID">> := Cen, <<"containerIDs">> := Conts}, Acc) ->
             [cen(binary_to_list(Cen),
-                 wire_type(Conts),
+                 bus,
                  Conts,
-                 leviathan_store:get_next_cin_ip()) | Acc]
+                 leviathan_cin:next_cenb()) | Acc]
         end, [], CensJson),
     Cens.
 
-wire_type(Conts) when length(Conts) < 2 ->
-    bus;
-    %null;
-wire_type(Conts) when length(Conts)  == 2 ->
-    bus;
-    %wire
-wire_type(Conts) when length(Conts)  > 2 ->
-    bus.
+cen(Cen, WireType, Conts, IpAddrB) ->
+    #{cenID => Cen,
+      wire_type => WireType,
+      contIDs => list_binary_to_list(Conts),
+      ipaddr_b => IpAddrB,
+      ip_address => binary_to_list(leviathan_cin:bridge_ip_address(IpAddrB)),
+      reservedIps => list_binary_to_list(container_ip_addrs(IpAddrB, Conts))}.
 
-% XXX ignore wiretype for now and always use bus
-cen(Cen, _WireType, Conts, IpAddr) ->
-     #{cenID => Cen,
-%      wire_type => WireType,
-       wire_type => bus,
-       contIDs => list_binary_to_list(Conts),
-       ip_address => binary_to_list(IpAddr)}.
+container_ip_addrs(IpAddrB, Conts) ->
+    lists:map(
+        fun(Count) ->
+            leviathan_cin:ip_address(IpAddrB, Count)
+        end, lists:seq(1, length(Conts))).
 
 % conts
 conts_from_jiffy(CensJson) ->
@@ -558,9 +536,16 @@ conts_from_jiffy(CensJson) ->
         end, #{}, Pairs),
     maps:fold(
         fun(Cont, Cens, Acc) ->
-            [#{contID => binary_to_list(Cont),
-               cens => list_binary_to_list(Cens)} | Acc]
+            [cont(Cont, Cens) | Acc]
         end, [], Index).
+
+cont(Cont, Cens) ->
+    #{contID => binary_to_list(Cont),
+      cens => list_binary_to_list(Cens),
+      reservedIdNums => cont_id_numbers(Cens)}.
+
+cont_id_numbers(Cens) ->
+    lists:seq(0, length(Cens) - 1).
 
 cen_cont_pairs(CensJson) ->
     lists:foldl(
@@ -586,26 +571,47 @@ maps_append_unique(Key, Value, Map) ->
 
 %% wiring helpers
 
-wire_cens(Cens) ->
+wire_cens(Cens, Conts) ->
     Fn =
-        fun(#{cenID := CenId,
-              contIDs := ContIds}, Acc) when length(ContIds) > 1 ->
-            wire_cen(CenId, ContIds) ++ Acc;
+        fun(Cen = #{cenID := CenId,
+                   contIDs := ContIds}, Acc) when length(ContIds) > 1 ->
+            IdNumbers = id_numbers(CenId, ContIds, Conts),
+            wire_cen(Cen, lists:zip(ContIds, IdNumbers)) ++ Acc;
            (_, Acc) ->
             Acc
          end,
     lists:foldl(Fn, [], Cens).
 
-wire_cen(CenId, ContIds) ->
-    lists:foldl(mk_wire_cont_to_cen_fun(CenId), [], ContIds).
+id_numbers(CenId, ContIds, Conts) ->
+    ContsMap = lists:foldl(
+        fun(Cont = #{contID := ContId}, Acc) ->
+            maps:put(ContId, id_number_for_cen(CenId, Cont), Acc)
+        end, #{}, Conts),
+    lists:map(
+        fun(ContId) ->
+            maps:get(ContId, ContsMap)
+        end, ContIds).
+
+id_number_for_cen(CenId, #{cens := Cens, reservedIdNums := ReservedIds}) ->
+    list_lookup2(CenId, Cens, ReservedIds).
+
+% ContInfo :: [{contid, id}]
+wire_cen(Cen = #{cenID := CenId}, ContsInfo) ->
+    IpAddrs = ipaddrs_for_conts(Cen, ContsInfo),
+    lists:foldl(mk_wire_cont_to_cen_fun(CenId),
+                [], lists:zip(ContsInfo, IpAddrs)).
+
+ipaddrs_for_conts(#{reservedIps := ReservedIps, contIDs := ContIds},
+                                                            ContsInfo) ->
+    lists:map(
+        fun({ContId, _}) ->
+            list_lookup2(ContId, ContIds, ReservedIps)
+        end, ContsInfo).
 
 mk_wire_cont_to_cen_fun(CenId) ->
-    fun(ContId, Acc) ->
-            #{idnumber := Id, ip_address := Ip} =
-                leviathan_store:get_wire_data(CenId, ContId),
+    fun({{ContId, Id}, Ip}, Acc) ->
             Wire = [mk_in_endpoint(CenId, ContId, Id, Ip),
                     mk_out_endpoint(CenId, ContId, Id)],
-            leviathan_store:wire_cont_to_cen(CenId, ContId, Wire),
             [Wire| Acc]
     end.
 
@@ -615,7 +621,7 @@ mk_in_endpoint(CenId, ContId, IdNumber, Ip) ->
       dest => #{type => cont,
                 id => ContId,
                 alias => CenId,
-                ip_address => binary_to_list(Ip)}
+                ip_address => Ip}
      }.
 
 mk_out_endpoint(CenId, ContId, IdNumber) ->
@@ -624,6 +630,15 @@ mk_out_endpoint(CenId, ContId, IdNumber) ->
       dest => #{type => cen,
                 id => CenId}
      }.
+
+% find the key in the first list argument and return the corresponding
+% value from the second list
+list_lookup2(Key, [], []) ->
+    error({no_key, Key});
+list_lookup2(Key, [Key | _], [Value | _]) ->
+    Value;
+list_lookup2(Key, [_ | Keys], [_ | Values]) ->
+    list_lookup2(Key, Keys, Values).
 
 % name formatters
 in_endpoint_name(ContId, N) ->

--- a/src/leviathan_cin.erl
+++ b/src/leviathan_cin.erl
@@ -1,6 +1,10 @@
 -module(leviathan_cin).
 
--export([ip_address/2,prepare_wire_end/1,cen_ip_address/1]).
+-export([ip_address/2,
+         prepare_wire_end/1,
+         cen_ip_address/1,
+         bridge_ip_address/1,
+         next_cenb/0]).
 
 % Generate an IP address in the form:
 % 10.NN.C1.C2
@@ -29,13 +33,10 @@ prepare_wire_end(#{type := cont, id := ContId, alias := Alias, ip_address := IPA
 
 cen_ip_address(NetCount) when NetCount =< 244 ->
     B = NetCount + 6, %% offset
-    list_to_binary(inet_parse:ntoa({10, B, 0, 1})).
+    bridge_ip_address(B).
 
+bridge_ip_address(CenB) ->
+    list_to_binary(inet_parse:ntoa({10, CenB, 0, 1})).
 
-
-
-
-
-
-
-
+next_cenb() ->
+    leviathan_store:next_count(cenb, 10).

--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -5,7 +5,8 @@
 -endif.
 
 -export([import_cens/2,
-         update_cens/2]).
+         update_cens/2,
+         import_switch/2]).
 
 -export([get_cen/1,
          get_cont/2,
@@ -28,6 +29,15 @@ import_cens(Host, CensMap) ->
     ToPublish = [container_from_lm(Host, CensMap),
                  cens_from_lm(Host, CensMap),
                  wires_from_lm(Host, CensMap)],
+    ok = dby:publish(?PUBLISHER, lists:flatten(ToPublish), [persistent]).
+
+% import switch
+
+import_switch(Host, Switch) ->
+    ToPublish = [dby_switch(Host, Switch),
+                 switch_ports(Host, Switch),
+                 %% One flow table should be enough for everyone.
+                 switch_tables(Host, Switch, 1)],
     ok = dby:publish(?PUBLISHER, lists:flatten(ToPublish), [persistent]).
 
 % getters
@@ -140,6 +150,15 @@ dby_endpoint_id(Host, Endpoint) ->
 dby_ipaddr_id(IpAddr) ->
     dby_id([<<"lev_ip">>, IpAddr]).
 
+dby_switch_id(Host, ContId) ->
+    dby_id([<<"lev_switch">>, Host, ContId]).
+
+dby_of_port_id(SwitchId, N) ->
+    <<SwitchId/binary, "/OFP", (integer_to_binary(N))/binary>>.
+
+dby_of_flow_table_id(SwitchId, N) ->
+    <<SwitchId/binary, "-table-", (integer_to_binary(N))/binary>>.
+
 dby_cen(CenId, Metadata) when is_binary(CenId) ->
     {dby_cen_id(CenId), [{<<"cenID">>, CenId},
 			 {<<"type">>, <<"cen">>}] ++ Metadata}.
@@ -160,6 +179,20 @@ dby_endpoint(Host, EndID, Side, Metadata) when is_binary(EndID) ->
 dby_ipaddr(IpAddr) when is_binary(IpAddr) ->
     {dby_ipaddr_id(IpAddr), [{<<"type">>, <<"ipaddr">>},
                              {<<"ipaddr">>, IpAddr}]}.
+
+dby_switch(Host, #{<<"contID">> := ContId}) ->
+    {dby_switch_id(Host, ContId),
+     [{<<"contID">>, ContId},
+      {<<"type">>, <<"of_switch">>}]}.
+
+dby_of_port(SwitchId, N) ->
+    {dby_of_port_id(SwitchId, N),
+     [{<<"type">>, <<"of_port">>}]}.
+
+dby_of_flow_table(SwitchId, N) ->
+    {dby_of_flow_table_id(SwitchId, N),
+     [{<<"type">>, <<"of_flow_table">>},
+      {<<"table_no">>, N}]}.
 
 dby_endpoint_to_ipaddr(Host, EndpointId, IpAddr) ->
     dby_link(dby_endpoint_id(Host, EndpointId), dby_ipaddr_id(IpAddr),
@@ -245,6 +278,22 @@ wires_from_lm(Host, #{wiremap := #{wires := Wires}}) ->
         fun(Wire, Acc) ->
             [pub_wire(Host, Wire) | Acc]
         end, [], Wires).
+
+switch_ports(Host, #{<<"contID">> := ContID, <<"interfaces">> := InterfacesBin}) ->
+    SwitchId = dby_switch_id(Host, ContID),
+    NumberedInterfaces = lists:zip(lists:seq(1, length(InterfacesBin)), InterfacesBin),
+    [
+     [dby_of_port(SwitchId, N),
+      dby_link(dby_of_port_id(SwitchId, N), SwitchId, <<"part_of">>),
+      dby_link(dby_of_port_id(SwitchId, N), dby_bridge_id(Host, Interface), <<"bound_to">>)]
+     || {N, Interface} <- NumberedInterfaces].
+
+switch_tables(Host, #{<<"contID">> := ContID}, HowMany) ->
+    SwitchId = dby_switch_id(Host, ContID),
+    [
+     [dby_of_flow_table(SwitchId, N),
+      dby_link(dby_of_flow_table_id(SwitchId, N), SwitchId, <<"of_resource">>)]
+     || N <- lists:seq(0, HowMany - 1)].
 
 % prepare to publish one wire
 pub_wire(Host, [Endpoint1 = #{endID := EndId1},

--- a/src/leviathan_dby.erl
+++ b/src/leviathan_dby.erl
@@ -201,10 +201,11 @@ dby_ipaddr(IpAddr) when is_binary(IpAddr) ->
     {dby_ipaddr_id(IpAddr), [{<<"type">>, <<"ipaddr">>},
                              {<<"ipaddr">>, IpAddr}]}.
 
-dby_switch(Host, #{<<"contID">> := ContId}) ->
+dby_switch(Host, #{<<"contID">> := ContId, <<"datapath_id">> := DatapathId}) ->
     {dby_switch_id(Host, ContId),
      [{<<"contID">>, ContId},
-      {<<"type">>, <<"of_switch">>}]}.
+      {<<"type">>, <<"of_switch">>},
+      {<<"datapath_id">>, DatapathId}]}.
 
 dby_of_port(SwitchId, N) ->
     {dby_of_port_id(SwitchId, N),

--- a/src/leviathan_ip.erl
+++ b/src/leviathan_ip.erl
@@ -50,4 +50,9 @@ netns_exec_ip_addr_add_dev(CPid,Address,DevName)->
 netns_exec_ip_route_add_default_via(CPid,Address)->
     "ip netns exec "  ++ CPid ++ " ip route add default via " ++ Address.
     
+%
+% Example: "ip netns exec $pid ip route add default dev cen2"
+%
+netns_exec_ip_route_add_default_dev(CPid,DevName)->
+    "ip netns exec "  ++ CPid ++ " ip route add default dev " ++ DevName.
     

--- a/src/leviathan_linux.erl
+++ b/src/leviathan_linux.erl
@@ -84,7 +84,9 @@ set_ip_address(Cid, Alias, IPAddress)->
     %% Use /0 as netmask, since the concept of "local network" doesn't
     %% make sense anymore.  Since the entire world is now our local
     %% network, we don't need a gateway either.
-    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/0",Alias)].
+    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/0",Alias),
+     %% Add a route to send everything out through the network interface.
+     leviathan_ip:netns_exec_ip_route_add_default_dev(CPid,Alias)].
 
 eval(CmdBundle)->
     EvalBundle = lists:map(fun(X)->Result = leviathan_os:cmd(X), {X,Result} end,CmdBundle),

--- a/src/leviathan_linux.erl
+++ b/src/leviathan_linux.erl
@@ -81,11 +81,10 @@ new_bridge(BridgeNum)->
 
 set_ip_address(Cid, Alias, IPAddress)->
     CPid = leviathan_docker:inspect_pid(Cid),
-    {ok,{A,B,_,_}} = inet:parse_ipv4_address(IPAddress),
-    Gateway = {A,B,0,1},
-    GatewayString = inet:ntoa(Gateway),
-    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/16",Alias), %% XXX hardcoded to /16
-     leviathan_ip:netns_exec_ip_route_add_default_via(CPid,GatewayString)].
+    %% Use /0 as netmask, since the concept of "local network" doesn't
+    %% make sense anymore.  Since the entire world is now our local
+    %% network, we don't need a gateway either.
+    [leviathan_ip:netns_exec_ip_addr_add_dev(CPid,IPAddress ++ "/0",Alias)].
 
 eval(CmdBundle)->
     EvalBundle = lists:map(fun(X)->Result = leviathan_os:cmd(X), {X,Result} end,CmdBundle),

--- a/src/leviathan_mnesia.erl
+++ b/src/leviathan_mnesia.erl
@@ -21,5 +21,8 @@ tabledefs() ->
                           {type, set}]},
         {leviathan_cont, [{attributes, record_info(fields, leviathan_cont)},
                           {disc_copies, [node()]},
-                          {type, bag}]}
+                          {type, bag}]},
+        {counter,        [{attributes, record_info(fields, counter)},
+                          {disc_copies, [node()]},
+                          {type, set}]}
     ].

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -37,15 +37,16 @@ run_switch(CType, Interfaces) ->
     {ok, ContainerId, DatapathId}.
 
 wait_for_new_connection(AlreadyConnected) ->
-    wait_for_new_connection(AlreadyConnected, 100).
+    wait_for_new_connection(AlreadyConnected, 10000).
 
-wait_for_new_connection(_, 0) ->
+wait_for_new_connection(_, N) when N =< 0 ->
     error(switch_connection_timeout);
 wait_for_new_connection(AlreadyConnected, N) when N > 0 ->
     case weave_ofsh:all_connected() -- AlreadyConnected of
         [] ->
-            timer:sleep(10),
-            wait_for_new_connection(AlreadyConnected, N - 1);
+            Sleep = 10,
+            timer:sleep(Sleep),
+            wait_for_new_connection(AlreadyConnected, N - Sleep);
         [DatapathId] ->
             list_to_binary(DatapathId)
     end.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -17,15 +17,35 @@ import_json(#{<<"type">> := CTypeBin,
               <<"interfaces">> := InterfacesBin} = Switch) ->
     CType = binary_to_list(CTypeBin),
     Interfaces = lists:map(fun binary_to_list/1, InterfacesBin),
-    {ok, ContainerId} = run_switch(CType, Interfaces),
-    %% XXX: get the datapath id!
-    DatapathId = <<"this-is-not-the-datapath-id-", ContainerId/binary>>,
+    {ok, ContainerId, DatapathId} = run_switch(CType, Interfaces),
     NewSwitch = Switch#{<<"contID">> => ContainerId,
                         <<"datapath_id">> => DatapathId},
     leviathan_dby:import_switch(<<"host1">>, NewSwitch).
 
 run_switch(CType, Interfaces) ->
+    AlreadyConnected = weave_ofsh:all_connected(),
+
     CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],
     [ContainerId] = leviathan_linux:eval(CmdBundle, output),
     io:format("switch results:~n~p~n", [ContainerId]),
-    {ok, ContainerId}.
+
+    %% XXX: Here we wait for a new incoming switch connection, and
+    %% assume that it's coming from the newly started container.  This
+    %% is a potential race condition.
+    DatapathId = wait_for_new_connection(AlreadyConnected),
+
+    {ok, ContainerId, DatapathId}.
+
+wait_for_new_connection(AlreadyConnected) ->
+    wait_for_new_connection(AlreadyConnected, 100).
+
+wait_for_new_connection(_, 0) ->
+    error(switch_connection_timeout);
+wait_for_new_connection(AlreadyConnected, N) when N > 0 ->
+    case weave_ofsh:all_connected() -- AlreadyConnected of
+        [] ->
+            timer:sleep(10),
+            wait_for_new_connection(AlreadyConnected, N - 1);
+        [DatapathId] ->
+            list_to_binary(DatapathId)
+    end.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -1,0 +1,11 @@
+-module(leviathan_switch).
+
+-compile(export_all).
+
+-include("leviathan_logger.hrl").
+
+run_switch(CType, Interfaces) ->
+    CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],
+    Result = leviathan_linux:eval(CmdBundle, output),
+    io:format("switch results:~n~p~n", [Result]),
+    ok.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -1,11 +1,27 @@
 -module(leviathan_switch).
 
--compile(export_all).
+-export(
+   [import_binary/1,
+    import_json/1,
+    run_switch/2]).
 
 -include("leviathan_logger.hrl").
 
+import_binary(Binary) ->
+    SwitchMap = jiffy:decode(Binary, [return_maps]),
+    import_json(SwitchMap).
+
+import_json(Switches) when is_list(Switches) ->
+    lists:foreach(fun import_json/1, Switches);
+import_json(#{<<"type">> := CTypeBin,
+              <<"interfaces">> := InterfacesBin} = Switch) ->
+    CType = binary_to_list(CTypeBin),
+    Interfaces = lists:map(fun binary_to_list/1, InterfacesBin),
+    {ok, ContainerId} = run_switch(CType, Interfaces),
+    leviathan_dby:import_switch(<<"host1">>, Switch#{<<"contID">> => ContainerId}).
+
 run_switch(CType, Interfaces) ->
     CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],
-    Result = leviathan_linux:eval(CmdBundle, output),
-    io:format("switch results:~n~p~n", [Result]),
-    ok.
+    [ContainerId] = leviathan_linux:eval(CmdBundle, output),
+    io:format("switch results:~n~p~n", [ContainerId]),
+    {ok, ContainerId}.

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -1,16 +1,46 @@
+%% @doc
+%% This module starts an OpenFlow switch and publishes the appropriate
+%% information to Dobby.
+%%
+%% Use it like this:
+%%
+%% ```
+%%     leviathan_switch:import_json(
+%%       #{<<"type">> => <<"local/linc">>,
+%%         <<"interfaces">> => [<<"cen1">>, <<"cen2">>]}).
+%% '''
+%%
+%% The Docker image named in the `type' attribute will be started with
+%% the options `--net=host --privileged=true', and the interface names
+%% will be passed as command line arguments.  The Docker image should
+%% have an `ENTRYPOINT' appropriately set to accept those arguments.
 -module(leviathan_switch).
 
 -export(
    [import_binary/1,
-    import_json/1,
-    run_switch/2]).
+    import_json/1]).
 
 -include("leviathan_logger.hrl").
 
+%% @doc Start one or more switches based on a JSON description.
+%%
+%% This function parses `Binary' as JSON and passes it to {@link
+%% import_json/1}.
 import_binary(Binary) ->
     SwitchMap = jiffy:decode(Binary, [return_maps]),
     import_json(SwitchMap).
 
+%% @doc Start one or more switches, and publish info to Dobby.
+%%
+%% The argument can be a single map, or a list of maps.  Each
+%% map should have two keys:
+%%
+%% The `<<"type">>' key should have a binary value, that names a
+%% Docker image.
+%%
+%% The `<<"interfaces">>' key should have a list of binaries,
+%% each naming an interface name that the newly started switch
+%% should manage.
 import_json(Switches) when is_list(Switches) ->
     lists:foreach(fun import_json/1, Switches);
 import_json(#{<<"type">> := CTypeBin,
@@ -22,6 +52,7 @@ import_json(#{<<"type">> := CTypeBin,
                         <<"datapath_id">> => DatapathId},
     leviathan_dby:import_switch(<<"host1">>, NewSwitch).
 
+%% @doc Start a switch, without publishing anything to Dobby.
 run_switch(CType, Interfaces) ->
     AlreadyConnected = weave_ofsh:all_connected(),
 

--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -18,7 +18,11 @@ import_json(#{<<"type">> := CTypeBin,
     CType = binary_to_list(CTypeBin),
     Interfaces = lists:map(fun binary_to_list/1, InterfacesBin),
     {ok, ContainerId} = run_switch(CType, Interfaces),
-    leviathan_dby:import_switch(<<"host1">>, Switch#{<<"contID">> => ContainerId}).
+    %% XXX: get the datapath id!
+    DatapathId = <<"this-is-not-the-datapath-id-", ContainerId/binary>>,
+    NewSwitch = Switch#{<<"contID">> => ContainerId,
+                        <<"datapath_id">> => DatapathId},
+    leviathan_dby:import_switch(<<"host1">>, NewSwitch).
 
 run_switch(CType, Interfaces) ->
     CmdBundle = [leviathan_docker:run(CType, "--net=host --privileged=true", string:join(Interfaces, " "))],


### PR DESCRIPTION
Added reservedIps to CEN and reservedIdNums to Cont maps in the Leviathan Map structure. Values for these are populated when the CEN and Containers are created and they are then used to compute the wires. This give us consistent wiring so the comparisons of LMs works better.
