### PR TITLE
Add leviathan_switch:wait_for_switch

### DIFF
--- a/src/leviathan_switch.erl
+++ b/src/leviathan_switch.erl
@@ -19,14 +19,17 @@
 
 -export(
    [import_binary/1,
-    import_json/1]).
+    import_json/1,
+    wait_for_switch/2]).
 
 -include("leviathan_logger.hrl").
 
 %% @doc Start one or more switches based on a JSON description.
 %%
 %% This function parses `Binary' as JSON and passes it to {@link
-%% import_json/1}.
+%% import_json/1}.  It returns a list of binaries: the datapath ids of
+%% the started switches.
+-spec import_binary(binary()) -> [binary()].
 import_binary(Binary) ->
     SwitchMap = jiffy:decode(Binary, [return_maps]),
     import_json(SwitchMap).
@@ -42,8 +45,14 @@ import_binary(Binary) ->
 %% The `<<"interfaces">>' key should have a list of binaries,
 %% each naming an interface name that the newly started switch
 %% should manage.
+%%
+%% This function returns a list of binaries: the datapath ids of the
+%% started switches.
+-spec import_json(Switch | [Switch]) -> [binary()]
+  %% XXX: can't specify types for map entries with binary keys.
+  when Switch :: map().
 import_json(Switches) when is_list(Switches) ->
-    lists:foreach(fun import_json/1, Switches);
+    lists:append(lists:map(fun import_json/1, Switches));
 import_json(#{<<"type">> := CTypeBin,
               <<"interfaces">> := InterfacesBin} = Switch) ->
     CType = binary_to_list(CTypeBin),
@@ -57,7 +66,8 @@ import_json(#{<<"type">> := CTypeBin,
     {ok, ContainerId} = run_switch(CType, DatapathId, Interfaces),
     NewSwitch = Switch#{<<"contID">> => ContainerId,
                         <<"datapath_id">> => DatapathIdBin},
-    leviathan_dby:import_switch(<<"host1">>, NewSwitch).
+    leviathan_dby:import_switch(<<"host1">>, NewSwitch),
+    [DatapathIdBin].
 
 %% @doc Start a switch, without publishing anything to Dobby.
 run_switch(CType, DatapathId, Interfaces) ->
@@ -76,3 +86,19 @@ integer_to_hex(I) ->
         [D] -> [$0, D];
         DD  -> DD
     end.
+
+%% @doc Wait for a connection from a switch with the given `DatapathId'.
+%%
+%% Wait for `Timeout' milliseconds before giving up.
+-spec wait_for_switch(binary(), integer()) -> 'ok' | {'error', 'timeout'}.
+wait_for_switch(DatapathId, Timeout) when is_integer(Timeout), Timeout >= 0 ->
+    case weave_ofsh:is_connected(DatapathId) of
+        true ->
+            ok;
+        false ->
+            Sleep = 100,
+            timer:sleep(Sleep),
+            wait_for_switch(DatapathId, Timeout - Sleep)
+    end;
+wait_for_switch(_, Timeout) when is_integer(Timeout), Timeout < 0 ->
+    {error, timeout}.


### PR DESCRIPTION
Also return datapath ids when starting switches.

This is to be used in `leviathan_rest`, in order not to return a status to the client until the switches are available for use.
