### PR TITLE
Refactor multi-host

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{require_otp_vsn, "1[78]"}.
+
 {sub_dirs, ["deps"]}.
 
 {deps,


### PR DESCRIPTION
This commit introduces various changes related updating the
network configuration based on the Dobby data model:
- API for sending/subscribing for CEN/CIN messages
- Add mapping CEN/CIN to hosts they span over
- Set initial status of imported CEN/CIN identifier as "importing"
- If deleting a tunnel fails, retry 4 times
- Do not set statuses of CEN/CIN identifiers in Dobby
- Change "destroy" status to "destroying"
